### PR TITLE
Translate interface to English

### DIFF
--- a/client/clientGUI.py
+++ b/client/clientGUI.py
@@ -129,34 +129,34 @@ class WerewolfClient(QMainWindow):
     def connect_to_server(self):
         username = self.username_input.text().strip()
         if not username:
-            QMessageBox.warning(self, "Erreur", "Veuillez entrer un nom d'utilisateur!")
+            QMessageBox.warning(self, "Error", "Please enter a username!")
             return
         self.username = username
         if self.network_worker.connect_to_server(username):
             self.network_thread.start()
-            self.connect_btn.setText("Connexion...")
+            self.connect_btn.setText("Connecting...")
             self.connect_btn.setEnabled(False)
         else:
-            QMessageBox.critical(self, "Erreur", "Impossible de se connecter au serveur!")
+            QMessageBox.critical(self, "Error", "Unable to connect to server!")
 
     def handle_connected(self):
-        self.status_label.setText("Connecté")
+        self.status_label.setText("Connected")
         self.status_label.setStyleSheet("color: #2ed573;")
-        self.connect_btn.setText("Connecté")
+        self.connect_btn.setText("Connected")
         self.set_game_controls_enabled(True)
-        self.add_chat_message("SYSTÈME", "Connecté au serveur avec succès!", "#2ed573")
+        self.add_chat_message("SYSTEM", "Connected to server successfully!", "#2ed573")
         
         # Ajouter le joueur local à sa propre liste
         if self.username and self.username not in [self.players_list_widget.item(i).text() for i in range(self.players_list_widget.count())]:
             self.players_list_widget.addItem(self.username)
 
     def handle_connection_lost(self):
-        self.status_label.setText("Connexion perdue")
+        self.status_label.setText("Connection lost")
         self.status_label.setStyleSheet("color: #ff6b6b;")
-        self.connect_btn.setText("Se connecter")
+        self.connect_btn.setText("Connect")
         self.connect_btn.setEnabled(True)
         self.set_game_controls_enabled(False)
-        self.add_chat_message("SYSTÈME", "Connexion perdue avec le serveur!", "#ff6b6b")
+        self.add_chat_message("SYSTEM", "Lost connection to the server!", "#ff6b6b")
 
     def handle_server_message(self, msg_type, payload):
         color_map = {
@@ -183,47 +183,47 @@ class WerewolfClient(QMainWindow):
         if msg_type == "ROLE":
             self.player_role = payload
             self.role_label.setText(payload)
-            self.add_chat_message("RÔLE", f"Vous êtes un {payload}!", color)
+            self.add_chat_message("ROLE", f"You are a {payload}!", color)
             
             # Mise à jour de la description du rôle
             role_descriptions = {
-                "villager": "Vous êtes un simple villageois. Votre but est de découvrir qui sont les loups-garous et de les éliminer lors des votes du village.",
-                "werewolf": "Vous êtes un loup-garou! Chaque nuit, vous pouvez voter pour dévorer un villageois. Durant le jour, cachez votre identité.",
-                "voyante": "Vous êtes la voyante. Chaque nuit, vous pouvez découvrir la véritable identité d'un joueur de votre choix.",
-                "sorcière": "Vous êtes la sorcière. Vous possédez deux potions: l'une pour sauver une victime, l'autre pour éliminer un joueur.",
-                "chasseur": "Vous êtes le chasseur. Si vous êtes éliminé, vous pouvez immédiatement tirer sur un autre joueur qui mourra aussi."
+                "villager": "You are a simple villager. Your goal is to find the werewolves and eliminate them during village votes.",
+                "werewolf": "You are a werewolf! Each night you may vote to devour a villager. During the day, hide your identity.",
+                "voyante": "You are the seer. Each night you can discover the true identity of a player of your choice.",
+                "sorcière": "You are the witch. You have two potions: one to save a victim, the other to eliminate a player.",
+                "chasseur": "You are the hunter. If eliminated, you can immediately shoot another player who will also die."
             }
-            self.role_desc_label.setText(role_descriptions.get(payload, "Rôle inconnu"))
+            self.role_desc_label.setText(role_descriptions.get(payload, "Unknown role"))
 
         elif msg_type == "STATE":
             self.game_state = payload
             
             # Traitement spécial pour certains états
             if payload == "villagers_win":
-                self.state_label.setText("Victoire des Villageois")
-                self.add_chat_message("VICTOIRE", "🎉 Les Villageois ont gagné!", "#2ed573")
-                QMessageBox.information(self, "Fin de partie", "Les villageois ont gagné! Les loups-garous ont été éliminés.")
+                self.state_label.setText("Villagers Victory")
+                self.add_chat_message("VICTORY", "🎉 Villagers have won!", "#2ed573")
+                QMessageBox.information(self, "Game Over", "Villagers have won! The werewolves were eliminated.")
                 
             elif payload == "werewolves_win":
-                self.state_label.setText("Victoire des Loups-garous")
-                self.add_chat_message("VICTOIRE", "🐺 Les Loups-garous ont gagné!", "#ff3838")
-                QMessageBox.information(self, "Fin de partie", "Les loups-garous ont gagné! Ils ont dévoré tous les villageois.")
+                self.state_label.setText("Werewolves Victory")
+                self.add_chat_message("VICTORY", "🐺 Werewolves have won!", "#ff3838")
+                QMessageBox.information(self, "Game Over", "Werewolves have won! They devoured all the villagers.")
                 
             elif payload == "day":
-                self.state_label.setText("Jour")
-                self.add_chat_message("ÉTAT", "☀️ Le jour se lève! Débattez et votez pour éliminer un suspect.", color)
+                self.state_label.setText("Day")
+                self.add_chat_message("STATE", "☀️ Day breaks! Discuss and vote to eliminate a suspect.", color)
                 # Mettre à jour l'interface pour le jour (en option)
                 # self.setStyleSheet("background-color: #87CEEB;") 
                 
             elif payload == "night":
-                self.state_label.setText("Nuit")
-                self.add_chat_message("ÉTAT", "🌙 La nuit tombe... Les rôles spéciaux agissent dans l'ombre.", color)
+                self.state_label.setText("Night")
+                self.add_chat_message("STATE", "🌙 Night falls... Special roles act in the shadows.", color)
                 # Mettre à jour l'interface pour la nuit (en option)
                 # self.setStyleSheet("background-color: #2C3E50;")
                 
             else:
                 self.state_label.setText(payload)
-                self.add_chat_message("ÉTAT", payload, color)
+                self.add_chat_message("STATE", payload, color)
                 
             # Mise à jour des contrôles uniquement
             # Les popups sont déclenchés par les messages spécifiques du serveur
@@ -242,9 +242,9 @@ class WerewolfClient(QMainWindow):
             # Format: nom_joueur:role
             try:
                 name, role = payload.split(":")
-                self.add_chat_message("VOYANTE", f"💫 Vous avez découvert que {name} est un {role}!", "#9c88ff")
-                # Afficher un message plus visible
-                QMessageBox.information(self, "Vision de la Voyante", f"Vous avez découvert que {name} est un {role}!")
+                self.add_chat_message("SEER", f"💫 You discovered that {name} is a {role}!", "#9c88ff")
+                # Show a more visible message
+                QMessageBox.information(self, "Seer's Vision", f"You discovered that {name} is a {role}!")
             except Exception as e:
                 print(f"Erreur traitement SEER_RESULT: {e}, payload: {payload}")
                 self.add_chat_message("VOYANTE", f"Résultat: {payload}", "#9c88ff")
@@ -256,18 +256,18 @@ class WerewolfClient(QMainWindow):
             # Ajouter le joueur à la liste
             if payload not in [self.players_list_widget.item(i).text() for i in range(self.players_list_widget.count())]:
                 self.players_list_widget.addItem(payload)
-                self.add_chat_message("JOUEUR", f"👋 {payload} a rejoint la partie!", "#3742fa")
+                self.add_chat_message("PLAYER", f"👋 {payload} joined the game!", "#3742fa")
                 
         elif msg_type == "ROLE_DISTRIBUTION":
             # Afficher la répartition des rôles
-            self.add_chat_message("INFORMATION", f"📊 Répartition des rôles dans cette partie: {payload}", "#3742fa")
-            # Afficher une fenêtre pop-up pour mettre en évidence cette information
-            QMessageBox.information(self, "Répartition des rôles", 
-                                    f"Voici la répartition des rôles dans cette partie:\n\n{payload}")
+            self.add_chat_message("INFO", f"📊 Role distribution for this game: {payload}", "#3742fa")
+            # Show a popup highlighting this information
+            QMessageBox.information(self, "Role distribution",
+                                    f"Here is the role distribution for this game:\n\n{payload}")
                 
         elif msg_type == "KILL":
             # Marquer le joueur comme mort dans la liste
-            self.add_chat_message("MORT", f"☠️ {payload} a été éliminé!", "#ff3838")
+            self.add_chat_message("DEATH", f"☠️ {payload} was eliminated!", "#ff3838")
             
             # Actualiser l'état du joueur dans la liste (en italique ou barré)
             for i in range(self.players_list_widget.count()):
@@ -289,11 +289,11 @@ class WerewolfClient(QMainWindow):
             # Vérifier si c'est nous qui sommes morts
             if payload == self.username:
                 if self.player_role == "chasseur":
-                    QMessageBox.information(self, "Vous êtes mort", 
-                                          "Vous avez été éliminé! En tant que chasseur, vous pouvez encore tirer sur quelqu'un.")
+                    QMessageBox.information(self, "You are dead",
+                                          "You have been eliminated! As the hunter you may still shoot someone.")
                 else:
-                    QMessageBox.information(self, "Vous êtes mort", 
-                                          "Vous avez été éliminé! Vous ne pouvez plus voter ni parler, mais vous pouvez continuer à observer la partie.")
+                    QMessageBox.information(self, "You are dead",
+                                          "You have been eliminated! You can no longer vote or speak but you may continue to observe the game.")
                 
         elif msg_type == "MSG":
             # Traiter les messages de chat
@@ -322,14 +322,14 @@ class WerewolfClient(QMainWindow):
     def create_connection_panel(self, parent_layout):
         conn_frame = QFrame()
         conn_layout = QHBoxLayout(conn_frame)
-        conn_layout.addWidget(QLabel("Nom d'utilisateur:"))
+        conn_layout.addWidget(QLabel("Username:"))
         self.username_input = QLineEdit()
-        self.username_input.setPlaceholderText("Entrez votre nom...")
+        self.username_input.setPlaceholderText("Enter your name...")
         conn_layout.addWidget(self.username_input)
-        self.connect_btn = QPushButton("Se connecter")
+        self.connect_btn = QPushButton("Connect")
         self.connect_btn.clicked.connect(self.connect_to_server)
         conn_layout.addWidget(self.connect_btn)
-        self.status_label = QLabel("Non connecté")
+        self.status_label = QLabel("Not connected")
         self.status_label.setStyleSheet("color: #ff6b6b;")
         conn_layout.addWidget(self.status_label)
         parent_layout.addWidget(conn_frame)
@@ -450,22 +450,22 @@ class WerewolfClient(QMainWindow):
         input_layout = QHBoxLayout()
         
         self.message_input = QLineEdit()
-        self.message_input.setPlaceholderText("Tapez votre message ou une commande /...")
+        self.message_input.setPlaceholderText("Type your message or a command /...")
         self.message_input.returnPressed.connect(self.send_chat_message)
         self.message_input.setStyleSheet("background-color: #2f3542; color: #f1f2f6; border-radius: 5px; padding: 5px;")
         
         # Boutons d'action rapide selon le contexte
         self.vote_btn = QPushButton("☀️ Vote")
-        self.vote_btn.setToolTip("Vote du jour (éliminer un joueur)")
+        self.vote_btn.setToolTip("Day vote (eliminate a player)")
         self.vote_btn.clicked.connect(self.show_vote_dialog)
         self.vote_btn.setStyleSheet("background-color: #ffa502;")
         
-        self.night_vote_btn = QPushButton("🌙 Action nocturne")
-        self.night_vote_btn.setToolTip("Action spéciale de nuit selon votre rôle")
+        self.night_vote_btn = QPushButton("🌙 Night action")
+        self.night_vote_btn.setToolTip("Night special action according to your role")
         self.night_vote_btn.clicked.connect(self.show_night_action_dialog)
         self.night_vote_btn.setStyleSheet("background-color: #9c88ff;")
         
-        send_btn = QPushButton("Envoyer")
+        send_btn = QPushButton("Send")
         send_btn.clicked.connect(self.send_chat_message)
         send_btn.setStyleSheet("background-color: #2ed573;")
         
@@ -495,9 +495,9 @@ class WerewolfClient(QMainWindow):
         
         # Filtres pour le journal
         filter_layout = QHBoxLayout()
-        filter_layout.addWidget(QLabel("Filtrer:"))
+        filter_layout.addWidget(QLabel("Filter:"))
         
-        filter_all = QPushButton("Tout")
+        filter_all = QPushButton("All")
         filter_all.clicked.connect(lambda: self.filter_log("all"))
         filter_layout.addWidget(filter_all)
         
@@ -505,20 +505,20 @@ class WerewolfClient(QMainWindow):
         filter_votes.clicked.connect(lambda: self.filter_log("vote"))
         filter_layout.addWidget(filter_votes)
         
-        filter_deaths = QPushButton("Morts")
+        filter_deaths = QPushButton("Deaths")
         filter_deaths.clicked.connect(lambda: self.filter_log("death"))
         filter_layout.addWidget(filter_deaths)
         
         log_layout.addLayout(filter_layout)
         
         # Ajout de l'onglet journal
-        chat_tabs.addTab(log_widget, "Journal")
+        chat_tabs.addTab(log_widget, "Log")
         
         # Onglet règles du jeu pour référence rapide
         rules_widget = QWidget()
         rules_layout = QVBoxLayout(rules_widget)
         
-        rules_title = QLabel("📋 Règles du jeu")
+        rules_title = QLabel("📋 Game Rules")
         rules_title.setStyleSheet("font-size: 14px; font-weight: bold;")
         rules_layout.addWidget(rules_title)
         
@@ -526,23 +526,23 @@ class WerewolfClient(QMainWindow):
         rules_text.setReadOnly(True)
         rules_text.setStyleSheet("background-color: #2f3542; color: #f1f2f6; border-radius: 5px;")
         rules_text.setHtml("""
-            <h3>Rôles du jeu</h3>
-            <p><b>🐺 Loup-garou</b>: Dévore un villageois chaque nuit</p>
-            <p><b>👁️ Voyante</b>: Peut découvrir l'identité d'un joueur chaque nuit</p>
-            <p><b>🧙‍♀️ Sorcière</b>: Peut sauver ou tuer un joueur avec ses potions</p>
-            <p><b>🔫 Chasseur</b>: À sa mort, peut emmener un autre joueur avec lui</p>
-            <p><b>👨‍🌾 Villageois</b>: Doit découvrir qui sont les loups-garous</p>
-            
-            <h3>Distribution optimale des rôles</h3>
-            <p>La répartition des rôles est automatiquement optimisée selon le nombre de joueurs:</p>
+            <h3>Game Roles</h3>
+            <p><b>🐺 Werewolf</b>: Devours one villager each night</p>
+            <p><b>👁️ Seer</b>: Can discover a player's identity each night</p>
+            <p><b>🧙‍♀️ Witch</b>: Can save or kill a player with her potions</p>
+            <p><b>🔫 Hunter</b>: Upon death can take another player down</p>
+            <p><b>👨‍🌾 Villager</b>: Must find out who the werewolves are</p>
+
+            <h3>Optimal role distribution</h3>
+            <p>Role distribution is automatically optimized based on player count:</p>
             <table border="1" cellpadding="5" style="border-collapse: collapse; color: #f1f2f6; width: 100%;">
                 <tr style="background-color: #3742fa;">
-                    <th>Joueurs</th>
-                    <th>🐺 Loups-garous</th>
-                    <th>👁️ Voyante</th>
-                    <th>🧙‍♀️ Sorcière</th>
-                    <th>🔫 Chasseur</th>
-                    <th>👨‍🌾 Villageois</th>
+                    <th>Players</th>
+                    <th>🐺 Werewolves</th>
+                    <th>👁️ Seer</th>
+                    <th>🧙‍♀️ Witch</th>
+                    <th>🔫 Hunter</th>
+                    <th>👨‍🌾 Villagers</th>
                 </tr>
                 <tr>
                     <td align="center">6</td>
@@ -582,22 +582,22 @@ class WerewolfClient(QMainWindow):
                     <td align="center">1</td>
                     <td align="center">1</td>
                     <td align="center">1</td>
-                    <td align="center">Reste</td>
+                    <td align="center">Rest</td>
                 </tr>
             </table>
-            
-            <h3>Déroulement</h3>
-            <p><b>Jour</b>: Les villageois débattent et votent pour éliminer un suspect</p>
-            <p><b>Nuit</b>: Les loups-garous choisissent une victime, puis les rôles spéciaux agissent</p>
-            
-            <h3>Victoire</h3>
-            <p>Les <b>villageois</b> gagnent s'ils éliminent tous les loups-garous</p>
-            <p>Les <b>loups-garous</b> gagnent s'ils sont en nombre égal ou supérieur aux villageois</p>
+
+            <h3>Gameplay</h3>
+            <p><b>Day</b>: Villagers debate and vote to eliminate a suspect</p>
+            <p><b>Night</b>: Werewolves choose a victim, then special roles act</p>
+
+            <h3>Victory</h3>
+            <p><b>Villagers</b> win if they eliminate all werewolves</p>
+            <p><b>Werewolves</b> win if they are at least as numerous as the villagers</p>
         """)
         rules_layout.addWidget(rules_text)
         
         # Ajout de l'onglet règles
-        chat_tabs.addTab(rules_widget, "Règles")
+        chat_tabs.addTab(rules_widget, "Rules")
         
         # Ajout des onglets au layout principal
         parent_layout.addWidget(chat_tabs, 1)
@@ -607,12 +607,12 @@ class WerewolfClient(QMainWindow):
 
     def create_command_panel(self, parent_layout):
     
-        cmd_group = QGroupBox("Terminal de commandes")
+        cmd_group = QGroupBox("Command Terminal")
         cmd_group.setStyleSheet("QGroupBox { font-weight: bold; font-size: 13px; }")
         cmd_group_layout = QVBoxLayout(cmd_group)
         
         # Affichage des commandes précédentes avec design amélioré
-        history_label = QLabel("Historique des commandes:")
+        history_label = QLabel("Command history:")
         history_label.setStyleSheet("font-weight: bold; color: #dfe4ea;")
         cmd_group_layout.addWidget(history_label)
         
@@ -620,7 +620,7 @@ class WerewolfClient(QMainWindow):
         self.cmd_history.setReadOnly(True)
         self.cmd_history.setMaximumHeight(100)
         self.cmd_history.setStyleSheet("background-color: #2f3542; color: #a4b0be; border-radius: 5px; font-family: 'Consolas', monospace;")
-        self.cmd_history.setPlaceholderText("Les commandes exécutées s'afficheront ici...")
+        self.cmd_history.setPlaceholderText("Executed commands will appear here...")
         cmd_group_layout.addWidget(self.cmd_history)
         
         # Zone de saisie des commandes avec style console
@@ -630,13 +630,13 @@ class WerewolfClient(QMainWindow):
         cmd_input_layout.addWidget(prompt_label)
         
         self.command_input = QLineEdit()
-        self.command_input.setPlaceholderText("/vote <joueur>, /nvote <joueur>, /start, /restart, /help")
+        self.command_input.setPlaceholderText("/vote <player>, /nvote <player>, /start, /restart, /help")
         self.command_input.setStyleSheet("background-color: #2f3542; color: #f1f2f6; border-radius: 5px; padding: 5px; font-family: 'Consolas', monospace;")
         self.command_input.returnPressed.connect(self.process_command)
         cmd_input_layout.addWidget(self.command_input)
         
         # Bouton d'exécution
-        exec_btn = QPushButton("▶️ Exécuter")
+        exec_btn = QPushButton("▶️ Run")
         exec_btn.clicked.connect(self.process_command)
         exec_btn.setStyleSheet("background-color: #2ed573; font-weight: bold;")
         cmd_input_layout.addWidget(exec_btn)
@@ -675,12 +675,12 @@ class WerewolfClient(QMainWindow):
         command_grid_layout.addWidget(cmd_nmsg, 1, 0)
         
         # Commandes pour les rôles spéciaux
-        cmd_seer = QPushButton("Voyante")
+        cmd_seer = QPushButton("Seer")
         cmd_seer.clicked.connect(lambda: self.show_seer_dialog())
         cmd_seer.setStyleSheet("background-color: #9c88ff;")
         command_grid_layout.addWidget(cmd_seer, 1, 1)
         
-        cmd_witch = QPushButton("Sorcière")
+        cmd_witch = QPushButton("Witch")
         cmd_witch.clicked.connect(lambda: self.show_witch_dialog())
         cmd_witch.setStyleSheet("background-color: #ff6348;")
         command_grid_layout.addWidget(cmd_witch, 1, 2)
@@ -695,7 +695,7 @@ class WerewolfClient(QMainWindow):
         
         # Ajouter la liste des commandes disponibles
         help_layout = QHBoxLayout()
-        help_layout.addWidget(QLabel("💡 Commandes:"))
+        help_layout.addWidget(QLabel("💡 Commands:"))
         help_text = QLabel("/vote, /nvote, /start, /restart, /nmsg, /help")
         help_text.setStyleSheet("font-style: italic; color: #a4b0be;")
         help_layout.addWidget(help_text)
@@ -720,78 +720,78 @@ class WerewolfClient(QMainWindow):
         
         # Actions en fonction de l'état du jeu et du rôle
         if self.game_state == "day":
-            vote_action = menu.addAction(f"🗳️ Voter contre {player_name}")
+            vote_action = menu.addAction(f"🗳️ Vote against {player_name}")
             vote_action.triggered.connect(lambda: self.vote_for_player(player_name))
             
         elif self.game_state == "night":
             if self.player_role == "werewolf":
-                night_vote_action = menu.addAction(f"🐺 Attaquer {player_name}")
+                night_vote_action = menu.addAction(f"🐺 Attack {player_name}")
                 night_vote_action.triggered.connect(lambda: self.night_vote_for_player(player_name))
                 
             elif self.player_role == "voyante":
-                see_action = menu.addAction(f"👁️ Examiner {player_name}")
+                see_action = menu.addAction(f"👁️ Inspect {player_name}")
                 see_action.triggered.connect(lambda: self.seer_examine_player(player_name))
                 
             elif self.player_role == "sorcière":
-                kill_action = menu.addAction(f"☠️ Empoisonner {player_name}")
+                kill_action = menu.addAction(f"☠️ Poison {player_name}")
                 kill_action.triggered.connect(lambda: self.witch_kill_player(player_name))
                 
             elif self.player_role == "chasseur":
-                shoot_action = menu.addAction(f"🔫 Tirer sur {player_name}")
+                shoot_action = menu.addAction(f"🔫 Shoot {player_name}")
                 shoot_action.triggered.connect(lambda: self.hunter_shoot_player(player_name))
             
         # Action de message privé (fonctionnalité à implémenter plus tard)
-        whisper_action = menu.addAction(f"💬 Message privé à {player_name}")
+        whisper_action = menu.addAction(f"💬 Private message to {player_name}")
         whisper_action.triggered.connect(lambda: self.whisper_to_player(player_name))
         
         # Afficher le menu
         menu.exec_(self.players_list_widget.mapToGlobal(position))
     
     def vote_for_player(self, player_name):
-        reply = QMessageBox.question(self, "Confirmation de vote", 
-                                     f"Voulez-vous voter contre {player_name}?", 
+        reply = QMessageBox.question(self, "Vote confirmation",
+                                     f"Do you want to vote against {player_name}?",
                                      QMessageBox.Yes | QMessageBox.No)
         if reply == QMessageBox.Yes:
             self.network_worker.send_message(MessageType.VOTE.value, player_name)
-            self.add_chat_message("VOTE", f"Vous avez voté contre {player_name}", "#ffa502")
+            self.add_chat_message("VOTE", f"You voted against {player_name}", "#ffa502")
             self.add_to_command_history(f"/vote {player_name}")
     
     def night_vote_for_player(self, player_name):
-        reply = QMessageBox.question(self, "Confirmation d'attaque", 
-                                     f"Voulez-vous attaquer {player_name} cette nuit?", 
+        reply = QMessageBox.question(self, "Attack confirmation",
+                                     f"Do you want to attack {player_name} tonight?",
                                      QMessageBox.Yes | QMessageBox.No)
         if reply == QMessageBox.Yes:
             self.network_worker.send_message(MessageType.NIGHT_VOTE.value, player_name)
-            self.add_chat_message("VOTE NOCTURNE", f"Vous avez choisi d'attaquer {player_name}", "#ff6b9d")
+            self.add_chat_message("NIGHT VOTE", f"You chose to attack {player_name}", "#ff6b9d")
             self.add_to_command_history(f"/nvote {player_name}")
     
     def seer_examine_player(self, player_name):
         self.network_worker.send_message(MessageType.SEER_ACTION.value, player_name)
-        self.add_chat_message("VOYANTE", f"Vous examinez {player_name}...", "#9c88ff")
+        self.add_chat_message("SEER", f"You examine {player_name}...", "#9c88ff")
         # On attend la réponse du serveur avec SEER_RESULT - voir handle_server_message
     
     def witch_kill_player(self, player_name):
         self.network_worker.send_message(MessageType.NIGHT_VOTE.value, f"witch_kill:{player_name}")
-        self.add_chat_message("SORCIÈRE", f"Vous avez empoisonné {player_name}", "#ff6348")
+        self.add_chat_message("WITCH", f"You poisoned {player_name}", "#ff6348")
     
     def hunter_shoot_player(self, player_name):
         self.network_worker.send_message(MessageType.HUNTER_SHOOT.value, player_name)
-        self.add_chat_message("CHASSEUR", f"Vous avez tiré sur {player_name}", "#ff9f43")
+        self.add_chat_message("HUNTER", f"You shot {player_name}", "#ff9f43")
     
     def whisper_to_player(self, player_name):
         # Fonctionnalité à implémenter plus tard
-        self.add_chat_message("SYSTÈME", f"Les messages privés ne sont pas encore implémentés", "#ff6b6b")
+        self.add_chat_message("SYSTEM", f"Private messages are not implemented yet", "#ff6b6b")
     
     def show_vote_dialog(self):
         if not self.players_list_widget.count():
-            QMessageBox.warning(self, "Vote impossible", "Aucun joueur disponible pour le vote.")
+            QMessageBox.warning(self, "Unable to vote", "No players available for voting.")
             return
             
         players = []
         for i in range(self.players_list_widget.count()):
             players.append(self.players_list_widget.item(i).text())
             
-        target, ok = QInputDialog.getItem(self, "Vote", "Choisissez un joueur à éliminer:", 
+        target, ok = QInputDialog.getItem(self, "Vote", "Choose a player to eliminate:",
                                         players, 0, False)
         if ok and target:
             self.vote_for_player(target)
@@ -802,8 +802,8 @@ class WerewolfClient(QMainWindow):
         
         # Vérifier si c'est actuellement la nuit
         if self.game_state != "night":
-            QMessageBox.information(self, "Action nocturne", 
-                                   "Les actions spéciales ne peuvent être effectuées que durant la nuit.")
+            QMessageBox.information(self, "Night action",
+                                   "Special actions can only be performed at night.")
             return
         
         # Afficher le dialogue approprié selon le rôle
@@ -816,8 +816,8 @@ class WerewolfClient(QMainWindow):
         elif self.player_role == "chasseur":
             self.show_hunter_dialog()
         else:
-            QMessageBox.information(self, "Action nocturne", 
-                                   "Vous n'avez pas d'action spéciale durant la nuit. Attendez que les autres joueurs finissent leurs actions.")
+            QMessageBox.information(self, "Night action",
+                                   "You have no special action tonight. Wait for the other players to finish their actions.")
 
     def show_night_vote_dialog(self):
         # Récupérer la liste des joueurs vivants depuis le widget de liste
@@ -845,7 +845,7 @@ class WerewolfClient(QMainWindow):
         # Vérifier si la liste n'est pas vide
         if not players:
             print("DEBUG - Liste des joueurs vide pour le vote nocturne!")
-            QMessageBox.warning(self, "Vote impossible", "Aucun joueur disponible pour le vote.")
+            QMessageBox.warning(self, "Unable to vote", "No players available for voting.")
             
             # Afficher tous les joueurs pour le débogage
             all_players = [self.players_list_widget.item(i).text() for i in range(self.players_list_widget.count())]
@@ -853,15 +853,15 @@ class WerewolfClient(QMainWindow):
             return
         
         print(f"DEBUG - Liste finale des joueurs pour le vote: {players}")
-        target, ok = QInputDialog.getItem(self, "Vote Nocturne", 
-                                       "Choisissez une victime pour cette nuit:", 
+        target, ok = QInputDialog.getItem(self, "Night Vote",
+                                       "Choose a victim for tonight:",
                                        players, 0, False)
         if ok and target:
             self.night_vote_for_player(target)
     
     def show_witch_dialog(self):
         dialog = QDialog(self)
-        dialog.setWindowTitle("Actions de la Sorcière")
+        dialog.setWindowTitle("Witch Actions")
         layout = QVBoxLayout(dialog)
         
         # Image ou icône pour la sorcière
@@ -875,12 +875,12 @@ class WerewolfClient(QMainWindow):
         witch_icon_label.setAlignment(Qt.AlignHCenter)
         layout.addWidget(witch_icon_label)
         
-        layout.addWidget(QLabel("Vous êtes la sorcière. Que souhaitez-vous faire?"))
+        layout.addWidget(QLabel("You are the witch. What do you want to do?"))
         
         # Options de la sorcière
-        no_action_btn = QPushButton("Ne rien faire")
-        save_btn = QPushButton("Sauver la victime")
-        kill_btn = QPushButton("Empoisonner un joueur")
+        no_action_btn = QPushButton("Do nothing")
+        save_btn = QPushButton("Save the victim")
+        kill_btn = QPushButton("Poison a player")
         
         layout.addWidget(no_action_btn)
         layout.addWidget(save_btn)
@@ -895,10 +895,10 @@ class WerewolfClient(QMainWindow):
     def witch_action(self, action, dialog):
         if action == "none":
             self.network_worker.send_message(MessageType.NIGHT_VOTE.value, "witch_none")
-            self.add_chat_message("SORCIÈRE", "Vous n'avez utilisé aucune potion", "#ff6348")
+            self.add_chat_message("WITCH", "You didn't use any potion", "#ff6348")
         elif action == "save":
             self.network_worker.send_message(MessageType.NIGHT_VOTE.value, "witch_save")
-            self.add_chat_message("SORCIÈRE", "Vous avez utilisé votre potion de vie pour sauver la victime", "#ff6348")
+            self.add_chat_message("WITCH", "You used your healing potion to save the victim", "#ff6348")
         dialog.accept()
     
     def witch_select_target(self, parent_dialog):
@@ -913,11 +913,11 @@ class WerewolfClient(QMainWindow):
         
         # Vérifier si la liste n'est pas vide
         if not players:
-            QMessageBox.warning(self, "Action impossible", "Aucun joueur disponible à empoisonner.")
+            QMessageBox.warning(self, "Action impossible", "No player available to poison.")
             return
             
-        target, ok = QInputDialog.getItem(self, "Empoisonnement", 
-                                       "Choisissez un joueur à empoisonner:", 
+        target, ok = QInputDialog.getItem(self, "Poison",
+                                       "Choose a player to poison:",
                                        players, 0, False)
         if ok and target:
             self.witch_kill_player(target)
@@ -956,12 +956,12 @@ class WerewolfClient(QMainWindow):
         # Vérifier si la liste n'est pas vide
         if not players:
             print("DEBUG - Liste des joueurs vide pour la voyante!")
-            QMessageBox.warning(self, "Action impossible", "Aucun joueur disponible à examiner.")
+            QMessageBox.warning(self, "Action impossible", "No player available to inspect.")
             return
             
         print(f"DEBUG - Liste finale pour la voyante: {players}")
-        target, ok = QInputDialog.getItem(self, "Vision de la Voyante", 
-                                       "Choisissez un joueur à examiner:", 
+        target, ok = QInputDialog.getItem(self, "Seer Vision",
+                                       "Choose a player to inspect:",
                                        players, 0, False)
         if ok and target:
             self.seer_examine_player(target)
@@ -976,11 +976,11 @@ class WerewolfClient(QMainWindow):
         
         # Vérifier si la liste n'est pas vide
         if not players:
-            QMessageBox.warning(self, "Action impossible", "Aucun joueur disponible sur qui tirer.")
+            QMessageBox.warning(self, "Action impossible", "No player available to shoot.")
             return
             
-        target, ok = QInputDialog.getItem(self, "Tir du Chasseur", 
-                                       "Choisissez un joueur sur qui tirer:", 
+        target, ok = QInputDialog.getItem(self, "Hunter Shot",
+                                       "Choose a player to shoot:",
                                        players, 0, False)
         if ok and target:
             self.hunter_shoot_player(target)
@@ -1026,10 +1026,10 @@ class WerewolfClient(QMainWindow):
             self.witch_kill_player(target)
         elif command == "/witch_save":
             self.network_worker.send_message(MessageType.NIGHT_VOTE.value, "witch_save")
-            self.add_chat_message("SORCIÈRE", "Vous avez utilisé votre potion de vie pour sauver la victime", "#ff6348")
+            self.add_chat_message("WITCH", "You used your healing potion to save the victim", "#ff6348")
         elif command == "/witch_none":
             self.network_worker.send_message(MessageType.NIGHT_VOTE.value, "witch_none")
-            self.add_chat_message("SORCIÈRE", "Vous n'avez utilisé aucune potion", "#ff6348")
+            self.add_chat_message("WITCH", "You didn't use any potion", "#ff6348")
         elif command.startswith("/hunter "):
             target = command.split(" ", 1)[1]
             self.hunter_shoot_player(target)
@@ -1059,25 +1059,25 @@ class WerewolfClient(QMainWindow):
 
     def show_help(self):
         help_text = (
-            "Commandes générales:\n"
-            "/vote <joueur> - Voter contre un joueur (jour)\n"
-            "/nvote <joueur> - Voter contre un joueur (nuit, loup-garou)\n"
-            "/start - Démarrer la partie\n"
-            "/restart - Redémarrer la partie\n\n"
-            
-            "Commandes de rôle:\n"
-            "/seer <joueur> - Examiner un joueur (voyante)\n"
-            "/witch_kill <joueur> - Empoisonner un joueur (sorcière)\n"
-            "/witch_save - Sauver la victime des loups (sorcière)\n"
-            "/witch_none - Ne rien faire (sorcière)\n"
-            "/hunter <joueur> - Tirer sur un joueur (chasseur)\n\n"
-            
-            "Autres commandes:\n"
-            "/nmsg <message> - Envoyer un message de nuit\n"
-            "/whisper <joueur> <message> - Envoyer un message privé à un joueur\n"
-            "/help - Afficher cette aide"
+            "General commands:\n"
+            "/vote <player> - Vote against a player (day)\n"
+            "/nvote <player> - Vote against a player (night, werewolf)\n"
+            "/start - Start the game\n"
+            "/restart - Restart the game\n\n"
+
+            "Role commands:\n"
+            "/seer <player> - Inspect a player (seer)\n"
+            "/witch_kill <player> - Poison a player (witch)\n"
+            "/witch_save - Save the werewolves' victim (witch)\n"
+            "/witch_none - Do nothing (witch)\n"
+            "/hunter <player> - Shoot a player (hunter)\n\n"
+
+            "Other commands:\n"
+            "/nmsg <message> - Send a night message\n"
+            "/whisper <player> <message> - Send a private message to a player\n"
+            "/help - Show this help"
         )
-        QMessageBox.information(self, "Aide", help_text)
+        QMessageBox.information(self, "Help", help_text)
 
     def set_game_controls_enabled(self, enabled):
         self.start_btn.setEnabled(enabled)
@@ -1141,9 +1141,9 @@ class WerewolfClient(QMainWindow):
         pass
     def closeEvent(self, event):
         """Gère la fermeture propre de l'application"""
-        reply = QMessageBox.question(self, 'Confirmation', 
-                                     'Êtes-vous sûr de vouloir quitter?',
-                                      QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+        reply = QMessageBox.question(self, 'Confirmation',
+                                     'Are you sure you want to quit?',
+                                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
                                       
         if reply == QMessageBox.Yes:
             if self.network_worker:

--- a/common/protocol.py
+++ b/common/protocol.py
@@ -27,7 +27,7 @@ def decode_message(raw_msg):
     except ValueError:
         return "", raw_msg
 
-# --- AJOUT POUR LA VOYANTE ---
+# --- ADDED FOR THE SEER ---
 def trigger_seer_phase(players):
     for conn, info in players.items():
         if info.get("role") == "voyante" and info.get("alive", True):
@@ -37,7 +37,7 @@ def trigger_seer_phase(players):
             except:
                 pass
 
-# --- AJOUT POUR LA RÉPONSE DE LA VOYANTE ---
+# --- ADDED FOR THE SEER RESPONSE ---
 def handle_seer_choice(players, seer_name, target_name):
     target_info = None
     for name, info in players.items():
@@ -54,7 +54,7 @@ def handle_seer_choice(players, seer_name, target_name):
                 except:
                     pass
 
-# --- AJOUT POUR LE CHASSEUR ---
+# --- ADDED FOR THE HUNTER ---
 def handle_hunter_death(players, hunter_name):
     for name, info in players.items():
         if name == hunter_name and info.get("role") == "chasseur":

--- a/server/game.py
+++ b/server/game.py
@@ -13,52 +13,52 @@ def assign_roles():
     Assign roles to players in the game.
     Balance roles based on the number of players, following standard werewolf game distributions.
     
-    Distribution optimale:
-    - 6 joueurs  : 1 loup-garou, 1 voyante, 1 sorcière, 3 villageois
-    - 8 joueurs  : 2 loups-garous, 1 voyante, 1 sorcière, 1 chasseur, 3 villageois
-    - 10 joueurs : 2 loups-garous, 1 voyante, 1 sorcière, 1 chasseur, 5 villageois
-    - 12 joueurs : 3 loups-garous, 1 voyante, 1 sorcière, 1 chasseur, 6 villageois
-    - 14 joueurs : 4 loups-garous, 1 voyante, 1 sorcière, 1 chasseur, 7 villageois
-    - 16+ joueurs: environ 1/4 de loups-garous, tous les rôles spéciaux, reste villageois
+    Optimal distribution:
+    - 6 players  : 1 werewolf, 1 seer, 1 witch, 3 villagers
+    - 8 players  : 2 werewolves, 1 seer, 1 witch, 1 hunter, 3 villagers
+    - 10 players : 2 werewolves, 1 seer, 1 witch, 1 hunter, 5 villagers
+    - 12 players : 3 werewolves, 1 seer, 1 witch, 1 hunter, 6 villagers
+    - 14 players : 4 werewolves, 1 seer, 1 witch, 1 hunter, 7 villagers
+    - 16+ players: about 1/4 werewolves, all special roles, remaining villagers
     """
     num_players = len(state.clients)
     roles = []
     
-    # Optimiser la répartition des loups-garous selon le nombre de joueurs
+    # Optimize werewolf distribution based on player count
     if num_players <= 6:
-        # 1 loup-garou pour 6 joueurs ou moins
+        # 1 werewolf for 6 or fewer players
         roles.append("werewolf")
     elif num_players <= 9:
-        # 2 loups-garous pour 7-9 joueurs
+        # 2 werewolves for 7-9 players
         roles.extend(["werewolf", "werewolf"])
     elif num_players <= 12:
-        # 3 loups-garous pour 10-12 joueurs
+        # 3 werewolves for 10-12 players
         roles.extend(["werewolf", "werewolf", "werewolf"])
     elif num_players <= 15:
-        # 4 loups-garous pour 13-15 joueurs
+        # 4 werewolves for 13-15 players
         roles.extend(["werewolf", "werewolf", "werewolf", "werewolf"])
     else:
-        # Pour 16+ joueurs: environ 1/4 des joueurs sont des loups-garous
+        # For 16+ players: about 1/4 are werewolves
         wolf_count = max(4, num_players // 4)
         roles.extend(["werewolf"] * wolf_count)
     
-    # Ajouter les rôles spéciaux selon le nombre de joueurs
+    # Add special roles based on player count
     if num_players >= 5:
-        roles.append("voyante")  # La voyante est toujours incluse à partir de 5 joueurs
+        roles.append("voyante")  # Include the seer starting at 5 players
     
     if num_players >= 6:
-        roles.append("sorcière")  # La sorcière est ajoutée à partir de 6 joueurs
+        roles.append("sorcière")  # Add the witch starting at 6 players
     
     if num_players >= 7:
-        roles.append("chasseur")  # Le chasseur est ajouté à partir de 7 joueurs
+        roles.append("chasseur")  # Add the hunter starting at 7 players
     
-    # Compléter avec des villageois
+    # Fill with villagers
     roles += ["villager"] * max(0, num_players - len(roles))
     
-    # Mélanger les rôles pour une distribution aléatoire
+    # Shuffle roles for random distribution
     random.shuffle(roles)
     
-    # Distribuer les rôles et notifier les joueurs
+    # Distribute roles and notify players
     for conn, role in zip(state.clients, roles):
         state.players[conn] = {
             "name": state.usernames[conn],
@@ -68,16 +68,16 @@ def assign_roles():
         msg = encode_message("ROLE", role) + "\n"
         conn.sendall(msg.encode())
         time.sleep(0.1)
-      # Logging des statistiques de distribution des rôles
+      # Log role distribution stats
     role_counts = {}
     for conn in state.players:
         role = state.players[conn]["role"]
         if role not in role_counts:
             role_counts[role] = 0
         role_counts[role] += 1
-      # Envoyer la distribution des rôles à tous les joueurs
+      # Send role distribution to all players
     distribution_list = [f"{count} {role}" for role, count in role_counts.items()]
-    # Formater le message pour une meilleure lisibilité
+    # Format the message for readability
     if "werewolf" in role_counts:
         wolf_count = role_counts["werewolf"]
         wolf_word = "werewolf" if wolf_count == 1 else "werewolves"
@@ -116,7 +116,7 @@ def change_state(new_state):
     state.votes.clear()
     broadcast(None, encode_message("STATE", new_state))
     if new_state == "night":
-        # Envoyer un message aux joueurs normaux pour qu'ils sachent qu'ils doivent attendre
+        # Notify normal players to wait during the night
         for conn, p in state.players.items():
             if p["alive"] and p["role"] not in ["voyante", "werewolf", "sorcière", "chasseur"]:
                 msg = encode_message("MSG", "Night falls... you fall asleep while others act in the shadows.") + "\n"
@@ -124,14 +124,14 @@ def change_state(new_state):
                     conn.sendall(msg.encode())
                 except:
                     pass
-        # Au début de la nuit, déclencher uniquement la voyante
-        # Les autres actions seront déclenchées en séquence après que chaque rôle ait terminé
+        # At the start of night, trigger only the seer
+        # Other actions occur sequentially after each role finishes
         time.sleep(3)
         
-        # 1. Voyante (peut examiner n'importe qui)
+        # 1. Seer (can inspect anyone)
         print("[GAME] Starting night sequence with seer phase")
         
-        # Vérifier s'il y a une voyante vivante
+        # Check if a living seer exists
         seer_exists = False
         for conn, p in state.players.items():
             if p["role"] == "voyante" and p["alive"]:
@@ -141,13 +141,13 @@ def change_state(new_state):
         if seer_exists:
             trigger_seer_phase()
         else:
-            # S'il n'y a pas de voyante, passer directement à la phase des loups-garous
+            # If no seer, skip directly to the werewolf phase
             print("[GAME] No living seer, skipping to werewolf phase")
             time.sleep(2)
             werewolf_night_phase()
             
-        # Les phases suivantes sont déclenchées après la fin de l'action de la voyante
-        # dans la fonction handle_seer_choice
+        # The following phases trigger after the seer action completes
+        # in handle_seer_choice
 
 
 def trigger_seer_phase():
@@ -164,8 +164,8 @@ def handle_seer_choice(conn, target_name):
             conn.sendall(encode_message("SEER_RESULT", result).encode())
             print(f"[GAME] Seer {state.usernames[conn]} examined {target_name} (role: {p['role']})")
             
-            # Maintenant que la voyante a fini son action, déclencher l'action des loups-garous
-            time.sleep(2)  # Petit délai pour s'assurer que le client a le temps de traiter la réponse
+            # Now that the seer finished, trigger the werewolf action
+            time.sleep(2)  # Small delay so the client has time to process the response
             print("[GAME] Seer action completed, starting werewolf phase")
             werewolf_night_phase()
             break
@@ -220,19 +220,19 @@ def kill_player(conn):
 
 def handle_hunter_death(conn):
     """
-    Permet au chasseur de tirer sur quelqu’un à sa mort.
+    Allows the hunter to shoot someone upon death.
     """
     conn.sendall(encode_message("HUNTER_SHOOT", "") + "\n")
 
 
 def check_end_game():
     """
-    Vérifie si le jeu est terminé.
+    Check if the game is over.
     """
     werewolves = [p for p in state.players.values() if p["role"] == "werewolf" and p["alive"]]
     villagers = [p for p in state.players.values() if p["role"] != "werewolf" and p["alive"]]
 
-    # Détails sur les joueurs restants pour le message de fin
+    # Details about remaining players for the end message
     werewolf_names = ", ".join([p["name"] for p in state.players.values() if p["role"] == "werewolf"])
     special_roles = ", ".join([f"{p['name']} ({p['role']})" for p in state.players.values() 
                                if p["role"] not in ["werewolf", "villager"]])
@@ -241,7 +241,7 @@ def check_end_game():
         state.set_game_state("end")
         broadcast(None, encode_message("STATE", "villagers_win") + "\n")
         
-        # Message détaillé sur les loups-garous qui étaient dans la partie
+        # Detailed message listing the werewolves in the game
         win_msg = f"Villagers have won! The werewolves ({werewolf_names}) were eliminated."
         if special_roles:
             win_msg += f"\nSpecial roles: {special_roles}"
@@ -251,7 +251,7 @@ def check_end_game():
         state.set_game_state("end")
         broadcast(None, encode_message("STATE", "werewolves_win") + "\n")
         
-        # Message détaillé sur les loups-garous qui ont gagné
+        # Detailed message for the winning werewolves
         win_msg = f"Werewolves ({werewolf_names}) have won! They now outnumber the villagers."
         if special_roles:
             win_msg += f"\nSpecial roles that failed to stop them: {special_roles}"
@@ -264,7 +264,7 @@ def werewolf_night_phase():
     """
     werewolves = [conn for conn, p in state.players.items() if p["role"] == "werewolf" and p["alive"]]
     
-    # S'assurer que la liste des loups-garous vivants n'est pas vide
+    # Ensure the living werewolves list is not empty
     if not werewolves:
         print("[GAME] No living werewolves to take action")
         return
@@ -276,9 +276,9 @@ def werewolf_night_phase():
         msg = encode_message("STATE", "You are the only werewolf. Choose a victim with /nvote <name>") + "\n"
         try:
             conn.sendall(msg.encode())
-            # Pause courte pour s'assurer que les messages sont envoyés dans le bon ordre
+            # Short pause to ensure messages are sent in order
             time.sleep(1)
-            # Envoyer un message spécifique pour déclencher la popup
+            # Send a specific message to trigger the popup
             msg_action = encode_message("WEREWOLF_ACTION", "") + "\n"
             conn.sendall(msg_action.encode())
             print(f"[GAME] Sent werewolf action to {state.usernames.get(conn, 'unknown')}")
@@ -289,9 +289,9 @@ def werewolf_night_phase():
         for conn in werewolves:
             try:
                 conn.sendall(msg.encode())
-                # Pause courte pour s'assurer que les messages sont envoyés dans le bon ordre
+                # Short pause to ensure messages are sent in order
                 time.sleep(1)
-                # Envoyer un message spécifique pour déclencher la popup
+                # Send a specific message to trigger the popup
                 msg_action = encode_message("WEREWOLF_ACTION", "") + "\n"
                 conn.sendall(msg_action.encode())
                 print(f"[GAME] Sent werewolf action to {state.usernames.get(conn, 'unknown')}")

--- a/server/handler.py
+++ b/server/handler.py
@@ -123,8 +123,8 @@ def handle_client(conn, addr):
 
 
 def handle_start(conn):
-    MIN_PLAYERS = 5  # Minimum absolu: 1 loup-garou, 1 voyante et 3 villageois
-    RECOMMENDED_PLAYERS = 6  # Recommandé: inclut aussi la sorcière
+    MIN_PLAYERS = 5  # Absolute minimum: 1 werewolf, 1 seer and 3 villagers
+    RECOMMENDED_PLAYERS = 6  # Recommended: also includes the witch
     if state.game_state != "waiting":
         conn.sendall((encode_message("STATE", "Game already started") + "\n").encode())
         return
@@ -132,9 +132,9 @@ def handle_start(conn):
         conn.sendall((encode_message("STATE", f"At least {MIN_PLAYERS} players are required to start the game") + "\n").encode())
         return
     elif len(state.clients) < RECOMMENDED_PLAYERS:
-        # On peut démarrer, mais on avertit que c'est mieux avec plus de joueurs
+        # We can start but warn that more players make a better game
         conn.sendall((encode_message("MSG", f"Note: {RECOMMENDED_PLAYERS}+ players are recommended for a balanced game with all roles") + "\n").encode())
-        # On continue le démarrage
+        # Continue starting
 
     assign_roles()
     change_state("night")
@@ -155,49 +155,49 @@ def handle_night_msg(conn, payload):
 
 
 def handle_night_vote(conn, payload):
-    # Traitement spécial pour les actions de la sorcière
+    # Special handling for witch actions
     if payload.startswith("witch_"):
         if not (state.players[conn]["alive"] and state.players[conn]["role"] == "sorcière"):
             return
             
         if payload == "witch_save":
-            # La sorcière sauve la victime désignée
+            # The witch saves the chosen victim
             print(f"[WITCH] {state.get_username(conn)} saved the victim")
-            # Reset des votes des loups-garous
+            # Reset werewolf votes
             for wolf_conn in [c for c, p in state.players.items() if p["role"] == "werewolf"]:
                 if wolf_conn in state.votes:
                     state.votes.pop(wolf_conn)
             
-            # Continuer le jeu après l'action de la sorcière
+            # Continue the game after the witch's action
             print("[GAME] Witch action completed, processing night results")
             time.sleep(2)
             tally_and_eliminate()
             return
             
         elif payload == "witch_none":
-            # La sorcière ne fait rien
+            # The witch does nothing
             print(f"[WITCH] {state.get_username(conn)} did nothing")
             
-            # Continuer le jeu après l'action de la sorcière
+            # Continue the game after the witch's action
             print("[GAME] Witch action completed, processing night results")
             time.sleep(2)
             tally_and_eliminate()
             return
             
         elif payload.startswith("witch_kill:"):
-            # La sorcière tue quelqu'un
+            # The witch kills someone
             target_name = payload.split(":")[1]
             target_conn = state.get_conn_by_username(target_name)
             if target_conn and state.players[target_conn]["alive"]:
                 print(f"[WITCH] {state.get_username(conn)} killed {target_name}")
                 kill_player(target_conn)
             
-            # Continuer le jeu après l'action de la sorcière
+            # Continue the game after the witch's action
             print("[GAME] Witch action completed, processing night results")
             time.sleep(2)
             tally_and_eliminate()
             return
-              # Traitement normal pour les loups-garous
+              # Normal processing for werewolves
     target_conn = state.get_conn_by_username(payload)
     if not target_conn:
         conn.sendall((encode_message("STATE", f"Player {payload} does not exist.") + "\n").encode())
@@ -215,10 +215,10 @@ def handle_night_vote(conn, payload):
 
     werewolves = [c for c, p in state.players.items() if p["alive"] and p["role"] == "werewolf"]
     if all(w in state.votes for w in werewolves):
-        # Tous les loups-garous ont voté, vérifier s'il y a une sorcière dans la partie
+        # All werewolves have voted, check for a witch in the game
         print("[GAME] All werewolves have voted, checking for witch...")
         
-        # Vérifier s'il y a une sorcière vivante dans la partie
+        # Check if there is a living witch in the game
         witch_exists = False
         for conn, p in state.players.items():
             if p["role"] == "sorcière" and p["alive"]:
@@ -226,13 +226,13 @@ def handle_night_vote(conn, payload):
                 break
                 
         if witch_exists:
-            # Il y a une sorcière vivante, déclencher sa phase
+            # A living witch exists, trigger her phase
             print("[GAME] Living witch found, starting witch phase")
             time.sleep(2)
             from server.game import trigger_witch_phase
             trigger_witch_phase()
         else:
-            # Pas de sorcière vivante ou pas de sorcière dans la partie, continuer directement avec l'élimination
+            # No living witch, proceed directly with elimination
             print("[GAME] No living witch found, proceeding directly with night results")
             time.sleep(2)
             tally_and_eliminate()
@@ -265,13 +265,13 @@ def handle_join(conn, addr, payload):
             state.set_username(conn, payload)
             print(f"[{addr}] joined as {payload}")
             
-            # Envoyer la liste des joueurs déjà connectés au nouveau client
+            # Send the list of already connected players to the new client
             existing_players = [state.get_username(c) for c in state.clients if c != conn and state.get_username(c)]
             for player in existing_players:
                 join_msg = encode_message("JOIN", player) + "\n"
                 conn.sendall(join_msg.encode())
             
-            # Diffuser aux autres clients qu'un nouveau joueur a rejoint
+            # Broadcast to other clients that a new player has joined
             join_broadcast = encode_message("JOIN", payload)
             broadcast(conn, join_broadcast)
             return True

--- a/server/handler.py
+++ b/server/handler.py
@@ -129,11 +129,11 @@ def handle_start(conn):
         conn.sendall((encode_message("STATE", "Game already started") + "\n").encode())
         return
     elif len(state.clients) < MIN_PLAYERS:
-        conn.sendall((encode_message("STATE", f"Il faut au moins {MIN_PLAYERS} joueurs pour démarrer la partie") + "\n").encode())
+        conn.sendall((encode_message("STATE", f"At least {MIN_PLAYERS} players are required to start the game") + "\n").encode())
         return
     elif len(state.clients) < RECOMMENDED_PLAYERS:
         # On peut démarrer, mais on avertit que c'est mieux avec plus de joueurs
-        conn.sendall((encode_message("MSG", f"Note: {RECOMMENDED_PLAYERS}+ joueurs recommandés pour une partie équilibrée avec tous les rôles") + "\n").encode())
+        conn.sendall((encode_message("MSG", f"Note: {RECOMMENDED_PLAYERS}+ players are recommended for a balanced game with all roles") + "\n").encode())
         # On continue le démarrage
 
     assign_roles()


### PR DESCRIPTION
## Summary
- translate server messages into English
- update role distribution output
- switch client GUI texts, tooltips, and dialogs to English

## Testing
- `python -m py_compile server/handler.py server/game.py client/clientGUI.py client/client.py`

------
https://chatgpt.com/codex/tasks/task_e_684797d6293c832894071d2491c16c4c